### PR TITLE
Add dependency version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## v0.37.0
+
+- When an `SQLiteConnection` instance is formed, check the version of SQLite that is
+  being used, and raise an exception if not version 3.35 or later. This is needed at
+  least for our use of the `RETURNING` keyword.
+
+- Add the package requirement that `gremlinpython` be less than `3.8.0`.
+  At this time, the only known divergence issue is in the change of `none()`
+  to `discard()`. See [the upgrade guide](https://tinkerpop.apache.org/docs/3.8.0/upgrade/#none-and-discard).
+  There may well be others; no effort has been made to check at this time.  
+
+  Accordingly, we now advance the `gremlite` version number to `0.37.0`, with the
+  intention that our minor version number will indicate which TinkerPop release we
+  intend to work with.

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,15 @@ GremLite is a fully functioning, serverless graph database. It uses Python's bui
 module to persist your data to disk, and it understands (much of) the Gremlin_ graph query language.
 (See language support below.)
 
+Requirements
+============
+
+SQLite 3.35 or later is required. You can check your version with:
+
+.. code-block:: shell
+
+   $ python -c "import sqlite3; print(sqlite3.sqlite_version)"
+
 Usage
 =====
 

--- a/gremlite/__init__.py
+++ b/gremlite/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     'get_g', 'SQLiteConnection', 'GremliteConfig',
 ]
 
-__version__ = '0.1.2'
+__version__ = '0.37.0-dev'

--- a/gremlite/base.py
+++ b/gremlite/base.py
@@ -179,6 +179,9 @@ class GremliteConfig:
         # of the Gremlin values those are meant to produce.
         self.traversal_returns_internal_result_iterator = False
 
+        # This is purely for testing purposes. It helps us test the code that checks the SQLite version.
+        self.phony_testing_sqlite_version_string = None
+
 
 class Step:
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    gremlinpython>=3.7.0
+    gremlinpython>=3.7.0,<3.8.0
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
We add:

* A runtime check that SQLite is of an adequate version number (3.35 or later)

* A package constraint that `gremlinpython` not go beyond `3.7.x`
