### PR TITLE
Make `read_all_at_once` default to `True`, and mark as experimental

### DIFF
--- a/tests/studies/cursor_logging.py
+++ b/tests/studies/cursor_logging.py
@@ -30,7 +30,7 @@ def main(log_level):
         path = pathlib.Path(dirname) / 'foo.db'
 
         conf = GremliteConfig()
-        conf.read_all_at_once = True
+        # conf.read_all_at_once = False
 
         # Form two connections to a single database:
         remote1 = SQLiteConnection(path, log_open_close=log_level, config=conf)


### PR DESCRIPTION
This ensures that all cursors close, by default, and as soon as possible.

It's not clear whether a `False` setting is really useful here or not.
For now, it is marked as "experimental". Later, maybe it should just be eliminated.